### PR TITLE
Repeat CryptoStream.Read() for .NET 6 compatibility

### DIFF
--- a/OvercookedTool/Program.cs
+++ b/OvercookedTool/Program.cs
@@ -179,7 +179,11 @@ namespace OvercookedTool
                     {
                         using (CryptoStream cryptoStream = new CryptoStream(memoryStream, transform, CryptoStreamMode.Read))
                         {
-                            cryptoStream.Read(array3, 0, array3.Length);
+			    // Modification from decompiled code: Repeat .Read() for .NET 6+.  See:
+			    // https://learn.microsoft.com/dotnet/core/compatibility/core-libraries/6.0/partial-byte-reads-in-streams
+			    // Original code:
+                            // cryptoStream.Read(array3, 0, array3.Length);
+			    for (int read, total = 0; (read = cryptoStream.Read(array3, total, array3.Length - total)) != 0; total += read) { }
                             memoryStream.Close();
                             cryptoStream.Close();
                             return array3;


### PR DESCRIPTION
.NET 6 changed `System.Security.Cryptography.CryptoStream.Read()` such that it may produce short reads (i.e. read less than the requested number of bytes) before the end of the stream is reached.  This is documented in [Partial and zero-byte reads in DeflateStream, GZipStream, and CryptoStream][partial-reads]. To support .NET 6 and later versions, call `.Read()` repeatedly, until the expected number of bytes has been read or end-of-stream has been reached.

[partial-reads]: https://learn.microsoft.com/dotnet/core/compatibility/core-libraries/6.0/partial-byte-reads-in-streams

Fixes: #23

This is an updated version of #24 by @SergejKiller with the changes requested by  @hadeutscher in https://github.com/hadeutscher/OvercookedTool/pull/24#issuecomment-2106297289 since it seems like work on that PR has stalled.  I have credited @SergejKiller in the commit message, since it was their work which solved the issue, I've merely simplified it.  I would be happy to defer to the original PR if it's updated.

Thanks for creating and maintaining this project!  I'm happy to be able to transfer my saved games between platforms,
Kevin